### PR TITLE
Another method for getting the cover image

### DIFF
--- a/epubthumbnail.desktop
+++ b/epubthumbnail.desktop
@@ -2,6 +2,7 @@
 Encoding=UTF-8
 Type=Service
 Name=ePub documents
+Name[de]=ePub-Dateien
 Name[it]=Documenti ePub
 Name[zh_CN]=ePub 文档
 X-KDE-ServiceTypes=ThumbCreator

--- a/epubthumbnail.h
+++ b/epubthumbnail.h
@@ -29,13 +29,13 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 class EPUBCreator : public QObject, public ThumbCreator
 {
     Q_OBJECT
-     
+
     public:
         explicit EPUBCreator();
         virtual ~EPUBCreator();
         virtual bool create(const QString& path, int width, int height, QImage& img);
         virtual Flags flags() const;
-        
+
     private:
         epub *mEpub;
         eiterator *mEiterator;
@@ -48,8 +48,12 @@ class EPUBCreator : public QObject, public ThumbCreator
         bool coverFromGuide();
         // try to retrieve the cover parsing the first xml/html file
         bool coverFromFirstFile();
+        // try to retrieve the cover parsing opf metadata section
+        bool coverFromMetadata();
         // parse the mCoverPage to find the mCoverName
         QImage searchCoverName();
+        // get image from mCoverName;
+        QImage getCoverImage();
         // fix some name problems
         void checkCoverName();
 };


### PR DESCRIPTION
With this additional method every of my ePub files now correctly shows its cover.
The only thing I'm not completely sure about is, if the images folder always is called "Images" with exactly this spelling.
For the ePubs I tested this was the case.
